### PR TITLE
feat: improve batch merge scan folder output matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nscb-desktop",
-  "version": "2.5.1",
+  "version": "2.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nscb-desktop",
-      "version": "2.5.1",
+      "version": "2.6.6",
       "license": "ISC",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -1489,6 +1489,48 @@ function VerifyPage() {
     );
 }
 
+// Parsed representation of an nscb_rust merge output filename.
+// Format: "GameName [TitleID] [vVersion] (Summary).ext"
+// Example: "Bayonetta 2 [0100847008600000] [v131072] (1G+1U+3D).nsp"
+interface ParsedMergeOutput {
+    filename: string;
+    gameName: string;
+    titleId: string;   // uppercase 16-hex
+    version: string;
+}
+
+function parseMergeOutputFilename(filename: string): ParsedMergeOutput | null {
+    const lastDot = filename.lastIndexOf('.');
+    if (lastDot === -1) return null;
+    const base = filename.substring(0, lastDot);
+    const m = base.match(/^(.+?)\s+\[([0-9A-Fa-f]{16})\]\s+\[v(\d+)\](?:\s+\([^)]+\))?$/i);
+    if (!m) return null;
+    return {
+        filename,
+        gameName: m[1],
+        titleId: m[2].toUpperCase(),
+        version: m[3],
+    };
+}
+
+// Extract the base title ID (ends in 000) from a list of input file paths.
+// Falls back to deriving from an update TID (ends in 800) if no base is found.
+function extractBaseTitleId(filePaths: string[]): string | null {
+    const tidRe = /[\[-]([0-9A-Fa-f]{16})[\]-]/gi;
+    const tids: string[] = [];
+    for (const fp of filePaths) {
+        const fname = fp.replace(/\\/g, '/').split('/').pop() ?? '';
+        for (const m of fname.matchAll(tidRe)) {
+            tids.push(m[1].toUpperCase());
+        }
+    }
+    const baseTid = tids.find(t => t.endsWith('000'));
+    if (baseTid) return baseTid;
+    const updTid = tids.find(t => t.endsWith('800'));
+    if (updTid) return updTid.slice(0, -3) + '000';
+    return null;
+}
+
 function BatchMergePage() {
     const [baseFolder, setBaseFolder] = useState('');
     const [outputDir, setOutputDir] = useState('');
@@ -1550,6 +1592,16 @@ function BatchMergePage() {
             let outputFiles: api.DirEntryInfo[] = [];
             try { outputFiles = await api.listDir(outputDir); } catch { /* empty output dir */ }
 
+            // Parse all switch files in the output dir into structured objects
+            const parsedOutputs = outputFiles
+                .filter(f => {
+                    if (f.isDirectory) return false;
+                    const ext = f.name.split('.').pop()?.toLowerCase() ?? '';
+                    return SWITCH_EXTS.has(ext);
+                })
+                .map(f => parseMergeOutputFilename(f.name))
+                .filter((p): p is ParsedMergeOutput => p !== null);
+
             const discovered: BatchGame[] = [];
             for (const sub of subfolders) {
                 if (!sub.name) continue;
@@ -1563,21 +1615,29 @@ function BatchMergePage() {
                 });
                 if (switchFiles.length === 0) continue;
 
-                const normName = normalizeForMatch(sub.name);
-                const alreadyExists = normName.length >= 3 && outputFiles.some(f => {
-                    if (f.isDirectory) return false;
-                    const ext = f.name.split('.').pop()?.toLowerCase() ?? '';
-                    if (!SWITCH_EXTS.has(ext)) return false;
-                    const base = f.name.substring(0, f.name.lastIndexOf('.'));
-                    return normalizeForMatch(base).includes(normName);
-                });
+                const filePaths = switchFiles.map(f => f.path);
+
+                // Prefer title ID match (most accurate — avoids substring confusion like
+                // "Bayonetta" matching a "Bayonetta 2" output). Fall back to exact
+                // normalized game name comparison (=== not includes).
+                let matchedOutput: ParsedMergeOutput | undefined;
+                const baseTid = extractBaseTitleId(filePaths);
+                if (baseTid) {
+                    matchedOutput = parsedOutputs.find(o => o.titleId === baseTid);
+                }
+                if (!matchedOutput) {
+                    const normName = normalizeForMatch(sub.name);
+                    if (normName.length >= 3) {
+                        matchedOutput = parsedOutputs.find(o => normalizeForMatch(o.gameName) === normName);
+                    }
+                }
 
                 discovered.push({
                     name: sub.name,
                     path: sub.path,
-                    files: switchFiles.map(f => f.path),
-                    status: alreadyExists ? 'skipped' : 'pending',
-                    message: alreadyExists ? 'Output already found in output folder' : undefined,
+                    files: filePaths,
+                    status: matchedOutput ? 'skipped' : 'pending',
+                    outputFile: matchedOutput?.filename,
                 });
             }
             setGames(discovered);

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -1513,22 +1513,37 @@ function parseMergeOutputFilename(filename: string): ParsedMergeOutput | null {
     };
 }
 
-// Extract the base title ID (ends in 000) from a list of input file paths.
-// Falls back to deriving from an update TID (ends in 800) if no base is found.
-function extractBaseTitleId(filePaths: string[]): string | null {
+// Extract all base title IDs from a list of input file paths.
+// Collects every distinct base TID found, so multi-game collection folders
+// (e.g. "Guacamelee One-Two Punch Collection" containing Guacamelee 1 & 2)
+// can match an output file named after any one of the included games.
+// Base TIDs end in 000; update (800) and DLC (001+) TIDs are normalised to base.
+function extractBaseTitleIds(filePaths: string[]): Set<string> {
     const tidRe = /[\[-]([0-9A-Fa-f]{16})[\]-]/gi;
-    const tids: string[] = [];
+    const baseTids = new Set<string>();
     for (const fp of filePaths) {
         const fname = fp.replace(/\\/g, '/').split('/').pop() ?? '';
         for (const m of fname.matchAll(tidRe)) {
-            tids.push(m[1].toUpperCase());
+            const tid = m[1].toUpperCase();
+            baseTids.add(tid.endsWith('000') ? tid : tid.slice(0, -3) + '000');
         }
     }
-    const baseTid = tids.find(t => t.endsWith('000'));
-    if (baseTid) return baseTid;
-    const updTid = tids.find(t => t.endsWith('800'));
-    if (updTid) return updTid.slice(0, -3) + '000';
-    return null;
+    return baseTids;
+}
+
+// Extract the highest version number found across all input file names.
+// Used to detect stale outputs where the output version < latest input version.
+function extractLatestVersion(filePaths: string[]): number {
+    const verRe = /\[v(\d+)\]/gi;
+    let latest = 0;
+    for (const fp of filePaths) {
+        const fname = fp.replace(/\\/g, '/').split('/').pop() ?? '';
+        for (const m of fname.matchAll(verRe)) {
+            const v = parseInt(m[1]);
+            if (v > latest) latest = v;
+        }
+    }
+    return latest;
 }
 
 function BatchMergePage() {
@@ -1617,18 +1632,48 @@ function BatchMergePage() {
 
                 const filePaths = switchFiles.map(f => f.path);
 
-                // Prefer title ID match (most accurate — avoids substring confusion like
-                // "Bayonetta" matching a "Bayonetta 2" output). Fall back to exact
-                // normalized game name comparison (=== not includes).
+                // Prefer title ID match — most accurate, handles multi-game collections
+                // (e.g. a folder with Guacamelee 1 & 2 files matches an output named
+                // after either game) and avoids name ambiguity entirely.
                 let matchedOutput: ParsedMergeOutput | undefined;
-                const baseTid = extractBaseTitleId(filePaths);
-                if (baseTid) {
-                    matchedOutput = parsedOutputs.find(o => o.titleId === baseTid);
+                let tidMatchStale = false;
+                const baseTids = extractBaseTitleIds(filePaths);
+                if (baseTids.size > 0) {
+                    matchedOutput = parsedOutputs.find(o => baseTids.has(o.titleId));
                 }
-                if (!matchedOutput) {
+                // Staleness check: if the matched output's version is lower than the
+                // latest version found in the input files, the output is out of date.
+                // e.g. folder has a new [UPD] file but output still shows [v0].
+                // Flag tidMatchStale so the name fallback doesn't re-match the same
+                // stale output (name matching would otherwise find it again by folder name).
+                if (matchedOutput) {
+                    const inputVer = extractLatestVersion(filePaths);
+                    if (inputVer > parseInt(matchedOutput.version)) {
+                        matchedOutput = undefined;
+                        tidMatchStale = true;
+                    }
+                }
+                // Name fallback for files without TIDs in their names.
+                // Skipped when TID matching already confirmed the output is stale.
+                // Three cases handled:
+                //   endsWith  — publisher prefix:  "Metal Slug 3" in "ACA NEOGEO METAL SLUG 3"
+                //   startsWith — volume suffix:    "Mega Man BN Legacy Collection" in
+                //                                  "MEGAMAN BN LEGACY COLLECTION Vol.1"
+                //                Guard: reject if the extra chars start with a digit,
+                //                which would indicate a sequel ("bayonetta" + "2") not a tag.
+                if (!matchedOutput && !tidMatchStale) {
                     const normName = normalizeForMatch(sub.name);
                     if (normName.length >= 3) {
-                        matchedOutput = parsedOutputs.find(o => normalizeForMatch(o.gameName) === normName);
+                        matchedOutput = parsedOutputs.find(o => {
+                            const n = normalizeForMatch(o.gameName);
+                            if (n === normName) return true;
+                            if (n.endsWith(normName)) return true;
+                            if (n.startsWith(normName)) {
+                                const extra = n.slice(normName.length);
+                                return !/^\d/.test(extra);
+                            }
+                            return false;
+                        });
                     }
                 }
 
@@ -1640,6 +1685,7 @@ function BatchMergePage() {
                     outputFile: matchedOutput?.filename,
                 });
             }
+            discovered.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
             setGames(discovered);
         } catch (e: any) {
             setGames([]);

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -1497,19 +1497,22 @@ interface ParsedMergeOutput {
     gameName: string;
     titleId: string;   // uppercase 16-hex
     version: string;
+    dlcCount: number;  // number of DLC packs included in the merge (from summary)
 }
 
 function parseMergeOutputFilename(filename: string): ParsedMergeOutput | null {
     const lastDot = filename.lastIndexOf('.');
     if (lastDot === -1) return null;
     const base = filename.substring(0, lastDot);
-    const m = base.match(/^(.+?)\s+\[([0-9A-Fa-f]{16})\]\s+\[v(\d+)\](?:\s+\([^)]+\))?$/i);
+    const m = base.match(/^(.+?)\s+\[([0-9A-Fa-f]{16})\]\s+\[v(\d+)\](?:\s+\(([^)]+)\))?$/i);
     if (!m) return null;
+    const dlcMatch = (m[4] ?? '').match(/(\d+)D/i);
     return {
         filename,
         gameName: m[1],
         titleId: m[2].toUpperCase(),
         version: m[3],
+        dlcCount: dlcMatch ? parseInt(dlcMatch[1]) : 0,
     };
 }
 
@@ -1529,6 +1532,23 @@ function extractBaseTitleIds(filePaths: string[]): Set<string> {
         }
     }
     return baseTids;
+}
+
+// Count distinct DLC title IDs in the input file names.
+// DLC TIDs end in 001–7FF (base = 000, update = 800).
+// Used to detect stale outputs where new DLC was added without a version bump.
+function countDlcFiles(filePaths: string[]): number {
+    const tidRe = /[\[-]([0-9A-Fa-f]{16})[\]-]/gi;
+    const dlcTids = new Set<string>();
+    for (const fp of filePaths) {
+        const fname = fp.replace(/\\/g, '/').split('/').pop() ?? '';
+        for (const m of fname.matchAll(tidRe)) {
+            const tid = m[1].toUpperCase();
+            const suffix = tid.slice(-3);
+            if (suffix !== '000' && suffix !== '800') dlcTids.add(tid);
+        }
+    }
+    return dlcTids.size;
 }
 
 // Extract the highest version number found across all input file names.
@@ -1635,11 +1655,18 @@ function BatchMergePage() {
                 // Prefer title ID match — most accurate, handles multi-game collections
                 // (e.g. a folder with Guacamelee 1 & 2 files matches an output named
                 // after either game) and avoids name ambiguity entirely.
+                // Pick the highest-version candidate — the output dir may contain both
+                // an old and a new merged file for the same game.
                 let matchedOutput: ParsedMergeOutput | undefined;
                 let tidMatchStale = false;
                 const baseTids = extractBaseTitleIds(filePaths);
                 if (baseTids.size > 0) {
-                    matchedOutput = parsedOutputs.find(o => baseTids.has(o.titleId));
+                    const candidates = parsedOutputs.filter(o => baseTids.has(o.titleId));
+                    if (candidates.length > 0) {
+                        matchedOutput = candidates.reduce((best, o) =>
+                            parseInt(o.version) > parseInt(best.version) ? o : best
+                        );
+                    }
                 }
                 // Staleness check: if the matched output's version is lower than the
                 // latest version found in the input files, the output is out of date.
@@ -1648,7 +1675,8 @@ function BatchMergePage() {
                 // stale output (name matching would otherwise find it again by folder name).
                 if (matchedOutput) {
                     const inputVer = extractLatestVersion(filePaths);
-                    if (inputVer > parseInt(matchedOutput.version)) {
+                    const inputDlc = countDlcFiles(filePaths);
+                    if (inputVer > parseInt(matchedOutput.version) || inputDlc > matchedOutput.dlcCount) {
                         matchedOutput = undefined;
                         tidMatchStale = true;
                     }

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -1544,8 +1544,8 @@ function countDlcFiles(filePaths: string[]): number {
         const fname = fp.replace(/\\/g, '/').split('/').pop() ?? '';
         for (const m of fname.matchAll(tidRe)) {
             const tid = m[1].toUpperCase();
-            const suffix = tid.slice(-3);
-            if (suffix !== '000' && suffix !== '800') dlcTids.add(tid);
+            const suffixValue = parseInt(tid.slice(-3), 16);
+            if (suffixValue >= 0x001 && suffixValue <= 0x7FF) dlcTids.add(tid);
         }
     }
     return dlcTids.size;
@@ -1692,7 +1692,7 @@ function BatchMergePage() {
                 if (!matchedOutput && !tidMatchStale) {
                     const normName = normalizeForMatch(sub.name);
                     if (normName.length >= 3) {
-                        matchedOutput = parsedOutputs.find(o => {
+                        const nameCandidates = parsedOutputs.filter(o => {
                             const n = normalizeForMatch(o.gameName);
                             if (n === normName) return true;
                             if (n.endsWith(normName)) return true;
@@ -1702,6 +1702,17 @@ function BatchMergePage() {
                             }
                             return false;
                         });
+                        if (nameCandidates.length > 0) {
+                            matchedOutput = nameCandidates.reduce((best, o) =>
+                                parseInt(o.version) > parseInt(best.version) ? o : best
+                            );
+                            // Apply the same staleness check as the TID path.
+                            const inputVer = extractLatestVersion(filePaths);
+                            const inputDlc = countDlcFiles(filePaths);
+                            if (inputVer > parseInt(matchedOutput.version) || inputDlc > matchedOutput.dlcCount) {
+                                matchedOutput = undefined;
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary

- **TID-based matching**: Parse `[TitleID]` from output filenames and input filenames for accurate Skipped/Pending detection, replacing unreliable name-string matching
- **Staleness detection**: Flag outputs as Pending when input files have a newer version (`[vN]`) or more DLC packs than the existing merged file
- **Multi-game collection support**: A folder containing files for multiple games (e.g. Guacamelee 1 & 2) correctly matches an output named after any included title
- **Publisher prefix / volume suffix handling**: Name fallback handles cases where the output name differs from the folder name (e.g. `Metal Slug 3` → `ACA NEOGEO METAL SLUG 3`, `Mega Man Battle Network Legacy Collection` → `...Vol.1`)
- **Sequel disambiguation**: Name fallback rejects matches where extra characters start with a digit (prevents `Bayonetta` matching `Bayonetta 2`)
- **Multiple outputs per game**: Picks the highest-version output when the output directory contains both old and new merged files for the same game
- **DLC count detection**: Detects stale outputs when new DLC files (TIDs ending `001`–`7FF`) are added to a folder without a version bump
- **Alphabetical sort**: Discovered games list is sorted alphabetically
- **Output filename display**: Matched output filename is shown in the Skipped status instead of a generic message

## Test plan

- [ ] Scan a folder — games with up-to-date merged outputs show as Skipped with the output filename
- [ ] Add a newer update file to a game folder — rescan shows it as Pending
- [ ] Add a new DLC file (with TID in filename) to a game folder — rescan shows it as Pending
- [ ] Games whose folder name differs from output name (publisher prefix, volume suffix) still match as Skipped
- [ ] Multi-game collection folders (e.g. Guacamelee One-Two Punch) match correctly
- [ ] `Bayonetta` folder does not false-positive match `Bayonetta 2` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)