### PR TITLE
fix: build Linux AppImage on ubuntu-24.04 to fix crash on Mesa 26+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             label: windows
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             label: linux
           - os: macos-latest


### PR DESCRIPTION
## Problem

The Linux AppImage crashes immediately on Fedora 44 (and any distro with Mesa 26+):

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

**Root cause:** The AppImage is built on `ubuntu-22.04`, which bundles WebKitGTK ~2.36/2.38. That version's `WebKitWebProcess` calls `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, ...)` with arguments Mesa 26 now strictly rejects with `EGL_BAD_PARAMETER`, triggering an unconditional `abort()`. No `WEBKIT_DISABLE_*` environment variable bypasses this — the crash is in platform initialization before any renderer selection.

Confirmed via `coredumpctl`: `WebKitWebProcess` (the bundled one) SIGABRTs on every launch; running the same app binary against system `webkit2gtk4.1` 2.52.3 on Fedora 44 / Mesa 26.0.6 works without issue.

## Fix

Switch the Linux CI runner from `ubuntu-22.04` to `ubuntu-24.04`. Ubuntu 24.04 ships WebKitGTK 2.44+ which has compatible GBM/EGL initialization. All four apt build dependencies (`libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `patchelf`) exist on 24.04 with identical package names — no other changes needed.

## Test environment

- Fedora 44, KDE Plasma (Wayland), Intel i915
- Mesa 26.0.6
- `webkit2gtk4.1` 2.52.3 (system)