### PR TITLE
fix: strip bundled Wayland libs from Linux AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,35 @@ jobs:
         if: matrix.label == 'linux'
         run: |
           mkdir -p staged
-          cp src-tauri/target/release/bundle/appimage/*.AppImage staged/nscb-desktop-linux-amd64.AppImage
           cp src-tauri/target/release/bundle/deb/*.deb staged/nscb-desktop-linux-amd64.deb
+
+          # Repack the AppImage without the bundled Wayland client libraries.
+          # linuxdeploy already excludes the host-coupled GL/EGL/DRM/X11 stack but
+          # not libwayland-*. A bundled libwayland-client older than the host's Mesa
+          # makes WebKitWebProcess abort with "EGL_BAD_PARAMETER" (blank window).
+          # Dropping them lets the host copies load. See cxfcxf/nscb-desktop#21.
+          src_appimage=$(ls src-tauri/target/release/bundle/appimage/*.AppImage)
+          rm -rf squashfs-root
+          "$src_appimage" --appimage-extract >/dev/null
+          rm -f squashfs-root/usr/lib/libwayland-client.so.* \
+                squashfs-root/usr/lib/libwayland-cursor.so.* \
+                squashfs-root/usr/lib/libwayland-egl.so.* \
+                squashfs-root/usr/lib/libwayland-server.so.*
+
+          curl -fsSL -o appimagetool \
+            https://github.com/AppImage/appimagetool/releases/download/1.9.0/appimagetool-x86_64.AppImage
+          chmod +x appimagetool
+          ARCH=x86_64 ./appimagetool --appimage-extract-and-run --no-appstream \
+            squashfs-root staged/nscb-desktop-linux-amd64.AppImage
+
+          # Guard: fail if the offending libraries survived the repack.
+          rm -rf squashfs-root
+          ./staged/nscb-desktop-linux-amd64.AppImage --appimage-extract >/dev/null
+          if ls squashfs-root/usr/lib/libwayland-* >/dev/null 2>&1; then
+            echo "ERROR: bundled libwayland-* still present in repacked AppImage" >&2
+            exit 1
+          fi
+          rm -rf squashfs-root
 
       - name: Stage artifact (macOS)
         if: matrix.label == 'macos'


### PR DESCRIPTION
## Problem

The Linux AppImage opens a blank window and aborts `WebKitWebProcess` on current Fedora (Mesa 26 / libwayland 1.25):

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

The main window opens, the renderer process crashes → blank window + a system crash report.

**This affects every AppImage release, not just the latest.** Every build so far bundles `libwayland-client.so.0` from the build host. Whether a given user hits the crash depends on how far their system's graphics stack has moved past that bundled copy:

- Rolling / fast-moving distros (Fedora, Arch, openSUSE Tumbleweed) hit it first.
- Older / stable distros haven't diverged far enough yet, so it still works there — for now.

The `ubuntu-22.04` → `ubuntu-24.04` switch in 5af08df did not change this mechanism. It bundled a slightly newer libwayland, which raised the threshold and bought some time, but the AppImage still ships a frozen libwayland that will fall behind every host eventually.

## Cause

The AppImage bundles `libwayland-client.so.0` (plus `-cursor`, `-egl`, `-server`) from the build host. The host's Mesa links `libwayland-client` during EGL init; when the bundled copy is older than the host Mesa expects, `eglGetPlatformDisplay` fails and WebKit aborts.

`linuxdeploy` already excludes the rest of the host-coupled graphics stack (`libGL`, `libEGL`, `libgbm`, `libdrm`, `libX11`, `libxcb`, …) so those load from the host — it just has a gap for `libwayland-*`.

This is **not** a WebKitGTK version issue: the bundled WebKit is 2.52.3, effectively the same as a working system copy.

## Fix

In the release workflow, after `npm run build`:

1. Extract the tauri-built AppImage (`--appimage-extract`, no FUSE needed).
2. Delete `usr/lib/libwayland-{client,cursor,egl,server}.so.*`.
3. Repack with a pinned `appimagetool` 1.9.0.
4. Guard step fails the build if any `libwayland-*` survived the repack.

The host's own `libwayland-*` then loads instead — these are present on every system that can run a GUI (Mesa depends on them). The `.deb` is unaffected (it links system libraries).

## Verification

Ran the extract → strip → repack locally against the actual v2.7.3 AppImage on Fedora 44 / Mesa 26.1.6:

| | Original v2.7.3 | Repacked |
|---|---|---|
| `WebKitWebProcess` | SIGABRT within ~1s | stable through 30s |
| Coredumps per run | 1 | 0 |
| UI | blank | renders |

The CI wiring itself (artifact glob, appimagetool download) is first exercised by a real tag build.